### PR TITLE
カレンダーの課題を提出

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -4,50 +4,26 @@ require "date"
 require 'optparse'
 
 today = Date.today
-params = {}
+params = {m:today.mon, y:today.year}
 
 opt = OptionParser.new
-opt.on('-m') {|v| params[:m] = v }
-opt.on('-y') {|v| params[:y] = v }
+opt.on('-m VALUE') {|v| params[:m] = v }
+opt.on('-y VALUE') {|v| params[:y] = v }
 opt.parse!(ARGV)
 
-# 引数の指定がなかった時、今年月を表示
-if params == {}
-  ARGV.push today.mon,today.year
-# -m（月）の入力がない時、今月を表示
-elsif params[:m] == nil
-  ARGV.unshift today.mon
-# -y（年）の入力がない時、今年を表示
-elsif params[:y] == nil
-  ARGV.push today.year
-end
-
-# -mと-yの入力順が逆の時、正しく表示されるようにする
-if params[:m] == true && params[:y] == true && ARGV[0] > "12"
-  ARGV.reverse!
-end
-
-# カレンダーの月と年を表示する
-month = ARGV[0].to_i
-year = ARGV[1].to_i
+month = params[:m].to_i
+year = params[:y].to_i
 puts "#{month}月 #{year}".center(20)
-
-# 曜日を表示する
 puts "日 月 火 水 木 金 土"
 
-# はじめの空白部分を出力
 first_date = Date.new(year, month, 1)
-brank_number = first_date.wday
-brank_number.times do |y|
-  print "   "
-end
+print '   ' * first_date.wday
 
-# 日付を出力
 last_date = Date.new(year, month, -1)
 (1..last_date.day).each do |x|
   printf('%2d', x)
   print " "
-  if (x + brank_number) % 7 == 0
+  if (x + first_date.wday) % 7 == 0
     puts "\n"
   end
   print 

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+
+# -mで月を、-yで年を指定できる
+# 引数を指定しない場合は、今月・今年のカレンダーが表示される
+require "date"
+today = Date.today
+
+params = {}
+require 'optparse'
+opt = OptionParser.new
+opt.on('-m') {|v| params[:m] = v }
+opt.on('-y') {|v| params[:y] = v }
+opt.parse!(ARGV)
+
+# 引数の指定がなかった時、今年月を表示
+if params == {}
+    ARGV.push today.mon,today.year
+# -m（月）の入力がない時、今月を表示
+elsif params[:m] == nil
+    ARGV.unshift today.mon
+# -y（年）の入力がない時、今年を表示
+elsif params[:y] == nil
+    ARGV.push today.year
+end
+
+# -mと-yの入力順が逆の時、正しく表示されるようにする
+if params[:m] == true && params[:y] == true && ARGV[0] > "12"
+    ARGV.reverse!
+end
+
+# カレンダーの月と年を表示する
+month = ARGV[0].to_i
+year = ARGV[1].to_i
+puts "#{month}月 #{year}".center(20)
+
+# 曜日を表示する
+puts "日 月 火 水 木 金 土"
+
+# はじめの空白部分を出力
+first_date = Date.new(year, month, 1)
+brank_number = first_date.wday
+brank_number.times do |y|
+    print "   "
+end
+
+# 日付を出力
+last_date = Date.new(year, month, -1)
+(1..last_date.day).each do |x|
+    printf('%2d', x)
+    print " "
+    if (x + brank_number) % 7 == 0
+        puts "\n"
+    end
+    print 
+end
+puts "\n"
+

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,12 +1,11 @@
 #!/usr/bin/env ruby
 
-# -mで月を、-yで年を指定できる
-# 引数を指定しない場合は、今月・今年のカレンダーが表示される
 require "date"
-today = Date.today
-
-params = {}
 require 'optparse'
+
+today = Date.today
+params = {}
+
 opt = OptionParser.new
 opt.on('-m') {|v| params[:m] = v }
 opt.on('-y') {|v| params[:y] = v }
@@ -14,18 +13,18 @@ opt.parse!(ARGV)
 
 # 引数の指定がなかった時、今年月を表示
 if params == {}
-    ARGV.push today.mon,today.year
+  ARGV.push today.mon,today.year
 # -m（月）の入力がない時、今月を表示
 elsif params[:m] == nil
-    ARGV.unshift today.mon
+  ARGV.unshift today.mon
 # -y（年）の入力がない時、今年を表示
 elsif params[:y] == nil
-    ARGV.push today.year
+  ARGV.push today.year
 end
 
 # -mと-yの入力順が逆の時、正しく表示されるようにする
 if params[:m] == true && params[:y] == true && ARGV[0] > "12"
-    ARGV.reverse!
+  ARGV.reverse!
 end
 
 # カレンダーの月と年を表示する
@@ -40,18 +39,18 @@ puts "日 月 火 水 木 金 土"
 first_date = Date.new(year, month, 1)
 brank_number = first_date.wday
 brank_number.times do |y|
-    print "   "
+  print "   "
 end
 
 # 日付を出力
 last_date = Date.new(year, month, -1)
 (1..last_date.day).each do |x|
-    printf('%2d', x)
-    print " "
-    if (x + brank_number) % 7 == 0
-        puts "\n"
-    end
-    print 
+  printf('%2d', x)
+  print " "
+  if (x + brank_number) % 7 == 0
+    puts "\n"
+  end
+  print 
 end
 puts "\n"
 


### PR DESCRIPTION
### 必須要件
- [x] ./cal.rb で実行できること(ruby cal.rb としなくてよいこと)
- [x] -mで月を、-yで年を指定できる
- [x] 引数を指定しない場合は、今月・今年のカレンダーが表示される
- [x] MacやWSLに入っているcalコマンドと同じ見た目になっている
- [x] 少なくとも1970年から2100年までは正しく表示される

1970年
<img width="383" alt="image" src="https://github.com/higashi27/ruby-practices/assets/114374897/d09e7bc4-4fd0-4504-af88-a6cac211d5d0">
2100年
<img width="382" alt="image" src="https://github.com/higashi27/ruby-practices/assets/114374897/951da4f7-2cc8-4b83-9d5e-9d2c3267a686">
